### PR TITLE
Fix nixos-generate command in 2024-09-05-nixos-proxmox-images.md

### DIFF
--- a/content/posts/2024-09-05-nixos-proxmox-images.md
+++ b/content/posts/2024-09-05-nixos-proxmox-images.md
@@ -35,7 +35,7 @@ Managing VMs gets even better. The `nixos-generators` package can convert a Nix 
 For example, you can run:
 
 ```
-nixos-generate -c proxmox -f configuration.nix
+nixos-generate -f proxmox -c configuration.nix
 ```
 
 Where `configuration.nix` is your NixOS configuration file (here's an example [gist](https://gist.github.com/joshleecreates/e6892ca21b0e6b7c24d96ca2a24bf23e)). This command creates a backup image you can upload and deploy to Proxmox.


### PR DESCRIPTION
See:
```
nixos-generate --help
Usage: /nix/store/307sbhbxim8z4v55iah4vlykk4ri2cdi-nixos-generators-1.8.0/bin/.nixos-generate-wrapped [options]

Options:

* --help: shows this help
* -c, --configuration PATH:
    select the nixos configuration to build. Default: /nix/store/307sbhbxim8z4v55iah4vlykk4ri2cdi-nixos-generators-1.8.0/share/nixos-generator/configuration.nix
* --flake URI:
    selects the nixos configuration to build, using flake uri like "~/dotfiles#my-config"
* -f, --format NAME: select one of the pre-determined formats
* --format-path PATH: pass a custom format
* --list: list the available built-in formats
* --run: runs the configuration in a VM
         only works for the "vm" and "vm-nogui" formats
* --show-trace: show more detailed nix evaluation location information
* --system: specify the target system (eg: x86_64-linux)
* -o, --out-link: specify the outlink location for nix-build
* --cores : to control the maximum amount of parallelism. (see nix-build documentation)
* --option : Passed to nix-build (see nix-build documentation).
* -I KEY=VALUE: Add a key to the Nix expression search path.
```