### PR TITLE
content: add FOSSY 2026 event

### DIFF
--- a/content/events/2026-08-06-fossy.md
+++ b/content/events/2026-08-06-fossy.md
@@ -1,0 +1,11 @@
+---
+title: "FOSSY"
+date: "2026-08-06T00:00:00Z"
+slug: fossy-26
+params:
+  location: "Vancouver, BC"
+  eventDate: 2026-08-06T12:00:00
+  eventURL: "https://2026.fossy.ca/schedule/presentation/403/"
+talks:
+- "O11y in One: ClickHouse as a Unified Telemetry Database"
+---


### PR DESCRIPTION
Summary:
- add FOSSY 2026 in Vancouver to the events list
- link the official session page for Josh Lee’s ClickHouse observability talk
- reuse the site’s established title for the existing O11y in One talk

Validation:
- `docker run --rm -v "$PWD:/project" -w /project ghcr.io/gohugoio/hugo:v0.138.0 --buildFuture`
- Hugo build completed successfully (166 pages)
